### PR TITLE
Add Meter component

### DIFF
--- a/lib/live_view_studio_web/components/meter.ex
+++ b/lib/live_view_studio_web/components/meter.ex
@@ -1,0 +1,21 @@
+defmodule LiveViewStudioWeb.Components.Meter do
+  use LiveViewStudioWeb, :surface_component
+
+  @doc "Name of input tag"
+  prop name, :string
+
+  @doc "Numeric value to display"
+  prop value, :number, default: 0
+
+  @doc "Unit of value"
+  prop unit, :string, required: true
+
+  def render(assigns) do
+    ~F"""
+    <div class="mt-1 relative rounded-md shadow-sm">
+      <input type="number" name={@name} value={@value} class="focus:ring-indigo-300 focus:border-indigo-300 block w-full min-w-0 pl-6 pr-16 text-sm border-slate-300 rounded-md transition duration-150 ease-in-out appearance-none">
+      <span class="absolute inset-y-0 right-0 pr-4 flex items-center pointer-events-none text-slate-500 text-sm">{@unit}</span>
+    </div>
+    """
+  end
+end

--- a/lib/live_view_studio_web/live/sandbox_live.ex
+++ b/lib/live_view_studio_web/live/sandbox_live.ex
@@ -3,6 +3,7 @@ defmodule LiveViewStudioWeb.SandboxLive do
 
   import Number.Currency
   alias LiveViewStudio.Sandbox
+  alias LiveViewStudioWeb.Components, as: C
 
   def mount(_params, _session, socket) do
     socket =
@@ -25,24 +26,15 @@ defmodule LiveViewStudioWeb.SandboxLive do
         <div class="fields">
           <div>
             <label for="length">Length</label>
-            <div class="input">
-              <input type="number" name="length" value={@length}>
-              <span class="unit">feet</span>
-            </div>
+            <C.Meter name="length" value={@length} unit="feet" />
           </div>
           <div>
             <label for="width">Width</label>
-            <div class="input">
-              <input type="number" name="width" value={@width}>
-              <span class="unit">feet</span>
-            </div>
+            <C.Meter name="width" value={@width} unit="feet" />
           </div>
           <div>
             <label for="depth">Depth</label>
-            <div class="input">
-              <input type="number" name="depth" value={@depth}>
-              <span class="unit">inches</span>
-            </div>
+            <C.Meter name="depth" value={@depth} unit="inches" />
           </div>
         </div>
         <div class="weight">

--- a/priv/catalogue/live_view_studio_web/components/meter_examples.ex
+++ b/priv/catalogue/live_view_studio_web/components/meter_examples.ex
@@ -1,0 +1,15 @@
+defmodule LiveViewStudioWeb.Components.MeterExamples do
+  use Surface.Catalogue.Examples,
+    subject: LiveViewStudioWeb.Components.Meter
+
+  alias LiveViewStudioWeb.Components.Meter
+
+  @example [
+    title: "basic"
+  ]
+  def basic_meter_example(assigns) do
+    ~F"""
+    <Meter name="amount-of-gold" unit="T" value={10} />
+    """
+  end
+end

--- a/priv/catalogue/live_view_studio_web/components/meter_playground.ex
+++ b/priv/catalogue/live_view_studio_web/components/meter_playground.ex
@@ -1,0 +1,9 @@
+defmodule LiveViewStudioWeb.Components.MeterPlayground do
+  use Surface.Catalogue.Playground, subject: LiveViewStudioWeb.Components.Meter, height: "100px"
+
+  @props [
+    name: "number of pig",
+    unit: "EA",
+    value: 42
+  ]
+end


### PR DESCRIPTION
## 개요
sandbox 예제에서 사용하는 input을 meter component로 생성하였습니다.  추가로 example 및 playground를 생성하였습니다.

## 수정사항
- `LiveViewStudioWeb.Components.Meter` Component 생성
- Sandbox 예제의 input을 `Meter` 컴포넌트로 변경
- `Meter` 컴포넌트의 에제 `MeterExamples` 추가
- `Meter` 컴포넌트의 playground `MeterPlayground` 추가